### PR TITLE
Fixing issue #705: fatal error on install

### DIFF
--- a/header.php
+++ b/header.php
@@ -156,12 +156,10 @@ else {
     setupGlobalVars(T_SETUP_GLOBAL_VARS__COMMON);
     require_once('modules/modsheader.php'); # Registration of modules.
     setupGlobalVars(T_SETUP_GLOBAL_VARS__POST_LOAD_MODULES);
+	
+	/******************************
+	   Translate skills globally
+	******************************/
+	global $lng;
+	$lng->TranslateSkills();
 }
-
-/******************************
-   Translate skills globally
-******************************/
-global $lng;
-$lng->TranslateSkills();
-
-


### PR DESCRIPTION
I ran through the installation and it doesn't seem to need skills to be translated, so I moved the call to this method inside of the main section of this conditional.

The problem was that the global $lng wasn't created during installation, because it's created during setupGlobalVars(T_SETUP_GLOBAL_VARS__COMMON)
