### PR TITLE
As per issues 689/690/692: Creation of match report from upload

### DIFF
--- a/modules/leegmgr/class_upload_botocs.php
+++ b/modules/leegmgr/class_upload_botocs.php
@@ -110,7 +110,7 @@ class UPLOAD_BOTOCS implements ModuleInterface
                     $this->homewinnings = (rand(1,6) + $this->homefame + 1) * 10000;
                     $this->success .= "\n".$this->winner." rerolled winnings of ".$oldwinnings." to get ".$this->homewinnings.".";
                 }
-                else if ( $reroll > ($this->awaywinnings / 10000 - $this->awayfame - 1) )
+                else if ( $this->winner == $this->awayteam && $reroll > ($this->awaywinnings / 10000 - $this->awayfame - 1) )
                 {
                     $oldwinnings = $this->awaywinnings;
                     $this->awaywinnings = (rand(1,6) + $this->awayfame + 1) * 10000;


### PR DESCRIPTION
When using the match uploader tool this will now create a match report so that there is a record of things like FF and winnings.

Also fixes bug where neither team could upload if match was drawn.

e.g.:

> Hardwoods coach rerolled winnings of 30000 to get 20000.Match report uploaded by the coach of the Hardwoods.
> 
> \=====================
> Results
> \=====================
> Home Team: Hardwoods
> Away Team: Richard
> Score: 3:2
> Winner: Hardwoods
> Hardwoods Fan Factor: 6
> Richard Fan Factor: 7
> Hardwoods Fans: 12000
> Richard Fans: 12000
> Hardwoods Fame: 0
> Richard Fame: 0
> Hardwoods Winnings: 40000 (3)
> Richard Winnings: 30000 (3)
> FF Rolls Hardwoods [2][6][4]: +1
> FF Rolls Richard [6][2]: +0
> Gate: 24000
